### PR TITLE
Support ulysses flash attn

### DIFF
--- a/easy_context/__init__.py
+++ b/easy_context/__init__.py
@@ -4,6 +4,8 @@ from .zigzag_ring_attn.prepare_inputs import prepare_zigzag_ring_attn_inputs
 from .zigzag_ring_attn.monkey_patch import apply_zigzag_ring_attn_monkey_patch_llama    
 from .zigzag_ring_attn.monkey_patch import apply_zigzag_ring_attn_monkey_patch_mistral
 from .unsloth_offloaded_gradient_checkpoint.monkey_patch import apply_unsloth_offloaded_gradient_checkpoint_monkey_patch
+from .ulysses_attn.prepare_inputs import prepare_ulysses_attn_inputs  
+from .ulysses_attn.monkey_patch import apply_ulysses_attn_monkey_patch_llama 
 
 def prepare_seq_parallel_inputs(
     seq_algo, input_ids, position_ids, target_ids, rank, world_size, device
@@ -14,6 +16,10 @@ def prepare_seq_parallel_inputs(
         )
     elif seq_algo == "dist_flash_attn":
         return prepare_dist_flash_attn_inputs(
+            input_ids, position_ids, target_ids, rank, world_size, device
+        )
+    elif seq_algo == "ulysses_attn":
+        return prepare_ulysses_attn_inputs(
             input_ids, position_ids, target_ids, rank, world_size, device
         )
     elif seq_algo == "data_parallel":
@@ -28,7 +34,7 @@ def prepare_seq_parallel_inputs(
 def apply_seq_parallel_monkey_patch(
     seq_algo, model
 ):
-    assert seq_algo in ["zigzag_ring_attn", "dist_flash_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
+    assert seq_algo in ["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
     assert model in ["llama", "mistral"], f"Invalid model: {model}"
     if seq_algo == "data_parallel":
         return
@@ -38,6 +44,8 @@ def apply_seq_parallel_monkey_patch(
         apply_zigzag_ring_attn_monkey_patch_mistral()
     elif seq_algo == "dist_flash_attn" and model == "llama":
         apply_dist_flash_attn_monkey_patch_llama()
+    elif seq_algo == "ulysses_attn" and model == "llama":
+        apply_ulysses_attn_monkey_patch_llama()
     else:
         raise ValueError(f"Invalid seq_algo: {seq_algo} or model: {model}")
         

--- a/easy_context/ulysses_attn/monkey_patch.py
+++ b/easy_context/ulysses_attn/monkey_patch.py
@@ -1,0 +1,107 @@
+import transformers
+from typing import List, Optional, Tuple, Union
+import warnings
+import torch
+import torch.utils.checkpoint
+from yunchang.ulysses import UlyssesAttention
+
+ulysses_attn = UlyssesAttention()
+
+def new_flash_attn_forward(
+    self,
+    query_states,
+    key_states,
+    value_states,
+    attention_mask,
+    query_length,
+    dropout=0.0,
+    softmax_scale=None,
+    use_sliding_windows=False,
+):
+    if not self._flash_attn_uses_top_left_mask:
+        causal = self.is_causal
+    else:
+        causal = self.is_causal and query_length != 1
+
+    # Contains at least one padding token in the sequence
+    assert attention_mask is None
+    assert causal is True
+    assert use_sliding_windows is False
+    attn_output = ulysses_attn(
+        query_states,
+        key_states,
+        value_states,
+        dropout,
+        softmax_scale,
+        causal=causal,
+    )
+
+    return attn_output
+
+
+def new_decoder_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: Optional[bool] = False,
+    use_cache: Optional[bool] = False,
+    cache_position: Optional[torch.LongTensor] = None,
+    **kwargs,
+) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    assert isinstance(
+        self.self_attn, transformers.models.llama.modeling_llama.LlamaFlashAttention2
+    ) or isinstance(
+        self.self_attn,
+        transformers.models.mistral.modeling_mistral.MistralFlashAttention2,
+    ), "Please toggle on the Flash Attention 2 implementation when using zigzag ring attention monkey patch."
+
+    if "padding_mask" in kwargs:
+        warnings.warn(
+            "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+        )
+
+    residual = hidden_states
+
+    hidden_states = self.input_layernorm(hidden_states)
+
+    # Self Attention
+    hidden_states, self_attn_weights, present_key_value = self.self_attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_value=past_key_value,
+        output_attentions=output_attentions,
+        use_cache=use_cache,
+        cache_position=cache_position,
+        **kwargs,
+    )
+    hidden_states = residual + hidden_states
+
+    # Fully Connected
+    residual = hidden_states
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = self.mlp(hidden_states)
+    hidden_states = residual + hidden_states
+
+    outputs = (hidden_states,)
+
+    if output_attentions:
+        outputs += (self_attn_weights,)
+
+    if use_cache:
+        outputs += (present_key_value,)
+
+    return outputs
+
+
+def apply_ulysses_attn_monkey_patch_llama():
+    transformers.models.llama.modeling_llama.LlamaFlashAttention2._flash_attention_forward = (
+        new_flash_attn_forward
+    )
+    transformers.models.llama.modeling_llama.LlamaDecoderLayer.forward = (
+        new_decoder_forward
+    )
+
+

--- a/easy_context/ulysses_attn/prepare_inputs.py
+++ b/easy_context/ulysses_attn/prepare_inputs.py
@@ -1,0 +1,45 @@
+import torch
+
+
+def extract_local(value, rank, world_size, device, dim=1):
+    dimension_size = value.shape[dim]
+    sub_seq_length = dimension_size // world_size
+
+    sub_seq_start = rank * sub_seq_length
+    sub_seq_end = (rank + 1) * sub_seq_length
+    local_value = value[:, sub_seq_start:sub_seq_end]
+
+    return local_value.to(device)
+
+
+def prepare_ulysses_attn_inputs(
+    input_ids, position_ids, target_ids, rank, world_size, device
+):
+
+    local_input_ids = extract_local(
+        input_ids,
+        rank,
+        world_size,
+        device,
+    )
+    local_position_ids = extract_local(
+        position_ids,
+        rank,
+        world_size,
+        device,
+    )
+
+    if target_ids is not None:
+        local_target_ids = extract_local(
+            target_ids,
+            rank,
+            world_size,
+            device,
+        )
+    else:
+        local_target_ids = None
+    return {
+        "local_input_ids": local_input_ids,
+        "local_position_ids": local_position_ids,
+        "local_target_ids": local_target_ids,
+    }

--- a/train.py
+++ b/train.py
@@ -207,6 +207,6 @@ if __name__ == "__main__":
     args.add_argument(
         "--parallel_mode",
         type=str,
-        choices=["zigzag_ring_attn", "dist_flash_attn", "data_parallel"],
+        choices=["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"],
     )
     main(args.parse_args())


### PR DESCRIPTION
Deepspeed Ulysses was proposed by Microsoft in [DeepSpeed Ulysses](https://arxiv.org/abs/2309.14509) , which implements a set of sequence parallelism using all-to-all communication, a method more efficient than p2p communication. Based on the Ulysses attention implemented in [long-context-attention](https://github.com/feifeibear/long-context-attention), I have added 'ulysses_attn' to the Easy Context framework on top of the three other parallel modes and have completed its implementation. According to experiments, the training results for long contexts are identical to those of ring attention, but the training speed is faster. When using it, please also clone the necessary folders from [long-context-attention](https://github.com/feifeibear/long-context-attention), which is consistent with the way you use ring attention.